### PR TITLE
chore: reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,13 @@ updates:
 - package-ecosystem: swift
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    # Check for updates to GitHub Actions every week
-    interval: "weekly"
-
+    interval: monthly
 - package-ecosystem: bundler
   directory: /
   schedule:
-    interval: daily
+    interval: monthly


### PR DESCRIPTION
I can't keep up with the weekly dependabot updates.