### PR TITLE
chore: use Internet Archive for Aspell

### DIFF
--- a/_posts/2005-08-10-darwinports-gnome-and-spell-checking.md
+++ b/_posts/2005-08-10-darwinports-gnome-and-spell-checking.md
@@ -8,6 +8,6 @@ redirect_from:
 ---
 It doesn&rsquo;t happen.
 
-The [DarwinPorts](https://macports.org) ports collection includes [aspell](https://savannah.gnu.org/projects/aspell/), but not [GtkSpell](https://GtkSpell.sourceforge.net) or [GnomeSpell](https://www.gnome.org) packages. So most of the Gnome software that supports spell checking apparently does not require it, and so I failed to notice that the software had no spell checking.
+The [DarwinPorts](https://macports.org) ports collection includes [aspell](https://web.archive.org/web/20250514111955/http://savannah.gnu.org/projects/aspell/), but not [GtkSpell](https://GtkSpell.sourceforge.net) or [GnomeSpell](https://www.gnome.org) packages. So most of the Gnome software that supports spell checking apparently does not require it, and so I failed to notice that the software had no spell checking.
 
 I guess I have a weekend project ahead of me making testable ports for GtkSpell and maybe GnomeSpell&hellip;


### PR DESCRIPTION
The GNU project's Aspell page keeps erroring in tests, so use the Internet Archive instead.